### PR TITLE
Fix module entry point and remove CDN import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,22 +47,9 @@
         animation: fade-in-down 0.5s ease-out forwards;
       }
     </style>
-  <script type="importmap">
-{
-  "imports": {
-    "react/": "https://aistudiocdn.com/react@^18.2.0/",
-    "react": "https://aistudiocdn.com/react@^18.2.0",
-    "recharts": "https://aistudiocdn.com/recharts@^2.12.0",
-    "react-dom/": "https://aistudiocdn.com/react-dom@^18.2.0/",
-    "react-dom/client": "https://aistudiocdn.com/react-dom@^18.2.0/client",
-    "@google/genai": "https://aistudiocdn.com/@google/genai@^1.22.0",
-    "@supabase/supabase-js": "https://aistudiocdn.com/@supabase/supabase-js@^2.45.0"
-  }
-}
-</script>
-</head>
+  </head>
   <body class="bg-navy-50 dark:bg-navy-950">
     <div id="root"></div>
-    <script type="module" src="./index.tsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -50,6 +50,6 @@
   </head>
   <body class="bg-navy-50 dark:bg-navy-950">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./index.tsx"></script>
   </body>
 </html>

--- a/index.tsx
+++ b/index.tsx
@@ -1,0 +1,1 @@
+import './src/main.tsx';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,12 @@
-
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
-import { ThemeProvider } from './contexts/ThemeProvider';
-import { NotificationProvider } from './contexts/NotificationProvider';
+import App from '@/App';
+import { ThemeProvider } from '@/contexts/ThemeProvider';
+import { NotificationProvider } from '@/contexts/NotificationProvider';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
-  throw new Error("Could not find root element to mount to");
+  throw new Error('Could not find root element to mount to');
 }
 
 const root = ReactDOM.createRoot(rootElement);
@@ -18,5 +17,6 @@ root.render(
         <App />
       </NotificationProvider>
     </ThemeProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );
+


### PR DESCRIPTION
## Summary
- remove the CDN import map from index.html so the app relies on the bundled dependencies
- move the React entry point into src/main.tsx and update the HTML entry script

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f49b2880832899a03eccf7efa7d7