### PR TITLE
Improve mobile navigation and stabilize auth session handling

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,7 @@ import { supabase } from '../lib/supabase';
 import ThemeToggle from './ThemeToggle';
 import Avatar from './Avatar';
 import { Profile, View } from '../types';
-import { UserCircleIcon } from './Icons';
+import { Bars3Icon, UserCircleIcon } from './Icons';
 
 interface HeaderProps {
     session: Session;
@@ -12,9 +12,10 @@ interface HeaderProps {
     theme: 'light' | 'dark';
     toggleTheme: () => void;
     setActiveView: (view: View) => void;
+    onMenuToggle: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ session, profile, theme, toggleTheme, setActiveView }) => {
+const Header: React.FC<HeaderProps> = ({ session, profile, theme, toggleTheme, setActiveView, onMenuToggle }) => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -34,8 +35,16 @@ const Header: React.FC<HeaderProps> = ({ session, profile, theme, toggleTheme, s
 
   return (
     <header className="flex-shrink-0 bg-white dark:bg-navy-800 border-b border-navy-200 dark:border-navy-700">
-      <div className="flex items-center justify-between p-4 h-16">
+      <div className="flex h-16 items-center justify-between p-4">
         <div className="flex items-center">
+          <button
+            type="button"
+            onClick={onMenuToggle}
+            className="mr-3 inline-flex items-center justify-center rounded-md p-2 text-navy-700 transition hover:bg-navy-100 focus:outline-none focus:ring-2 focus:ring-usace-red focus:ring-offset-2 dark:text-navy-200 dark:hover:bg-navy-700 dark:focus:ring-offset-navy-800 lg:hidden"
+            aria-label="Toggle navigation menu"
+          >
+            <Bars3Icon className="h-6 w-6" />
+          </button>
           <h1 className="text-xl font-semibold text-navy-800 dark:text-white tracking-tight">
             PAO KPI Tracker
           </h1>

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -16,6 +16,34 @@ export const UsaceLogoIcon = (props: { className?: string }) => (
   </svg>
 );
 
+export const Bars3Icon = (props: { className?: string }) => (
+  <svg
+    {...props}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5" />
+  </svg>
+);
+
+export const XMarkIcon = (props: { className?: string }) => (
+  <svg
+    {...props}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6m0 12L6 6" />
+  </svg>
+);
+
 export const HomeIcon = (props: { className?: string }) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true">
         <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h7.5" />

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -2,28 +2,51 @@
 
 import React from 'react';
 import { NavItem, View } from '../types';
-import { UsaceLogoIcon } from './Icons';
+import { UsaceLogoIcon, XMarkIcon } from './Icons';
 
 interface SidebarProps {
   navigationItems: NavItem[];
   activeView: View;
   setActiveView: (view: View) => void;
+  isOpen?: boolean;
+  onClose?: () => void;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ navigationItems, activeView, setActiveView }) => {
+const Sidebar: React.FC<SidebarProps> = ({ navigationItems, activeView, setActiveView, isOpen = true, onClose }) => {
+  const handleNavigate = (view: View) => {
+    setActiveView(view);
+    if (onClose) {
+      onClose();
+    }
+  };
+
   return (
-    <aside className="w-64 flex-shrink-0 bg-usace-blue text-white flex flex-col">
-      <div className="h-16 flex items-center justify-center p-4 border-b border-navy-600">
+    <aside
+      className={`fixed inset-y-0 left-0 z-40 flex w-64 transform flex-col bg-usace-blue text-white shadow-xl transition-transform duration-300 ease-in-out lg:static lg:z-auto lg:translate-x-0 lg:flex-shrink-0 lg:shadow-none ${
+        isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
+      }`}
+    >
+      <div className="relative flex h-16 items-center justify-center border-b border-navy-600 p-4">
         <div className="flex items-center space-x-3">
           <UsaceLogoIcon className="h-8 w-8 text-usace-red" />
           <span className="font-bold text-lg tracking-wider">USACE</span>
         </div>
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full p-2 text-navy-100 transition hover:bg-white/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-white lg:hidden"
+            aria-label="Close navigation"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        )}
       </div>
-      <nav className="flex-1 px-4 py-6 space-y-2">
+      <nav className="flex-1 space-y-2 overflow-y-auto px-4 py-6">
         {navigationItems.map((item) => (
           <button
             key={item.id}
-            onClick={() => setActiveView(item.id)}
+            onClick={() => handleNavigate(item.id)}
             className={`w-full flex items-center px-4 py-2.5 text-sm font-medium rounded-md transition-colors duration-200 ${
               activeView === item.id
                 ? 'bg-usace-red text-white'
@@ -35,8 +58,8 @@ const Sidebar: React.FC<SidebarProps> = ({ navigationItems, activeView, setActiv
           </button>
         ))}
       </nav>
-      <div className="p-4 border-t border-navy-600">
-         <p className="text-xs text-center text-navy-300">&copy; 2024 USACE PAO</p>
+      <div className="border-t border-navy-600 p-4">
+        <p className="text-center text-xs text-navy-300">&copy; 2024 USACE PAO</p>
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- make the sidebar responsive by adding a mobile toggle, overlay, and close interactions
- add reusable menu and close icons to support the new navigation controls
- refine auth session management to avoid redundant reloads when returning to the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e508c8d3608328a5149aed90c44398