### PR TITLE
Add social media management view with feed connection controls

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import DataEntry from './components/DataEntry';
 import PlanBuilder from './components/PlanBuilder';
 import Campaigns from './components/Campaigns';
 import GoalSetter from './components/GoalSetter';
+import SocialMedia from './components/SocialMedia';
 import Auth from './components/Auth';
 import ProfilePage from './components/ProfilePage';
 import { supabase } from './lib/supabase';
@@ -302,6 +303,8 @@ const App: React.FC = () => {
         return <Campaigns campaigns={campaigns} onAddCampaign={addCampaign} />;
       case 'goals':
         return <GoalSetter goals={goals} onAddGoal={addGoal} campaigns={campaigns} />;
+      case 'social-media':
+        return <SocialMedia role={profile.role} />;
       case 'profile':
         return <ProfilePage session={session!} profile={profile} onProfileUpdate={onProfileUpdate} />;
       default:

--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,13 @@
 import { KpiDataPoint, EntryType, NavItem, Campaign } from './types';
-import { HomeIcon, TableCellsIcon, DocumentPlusIcon, ClipboardDocumentListIcon, MegaphoneIcon, TrophyIcon } from './components/Icons';
+import {
+  HomeIcon,
+  TableCellsIcon,
+  DocumentPlusIcon,
+  ClipboardDocumentListIcon,
+  MegaphoneIcon,
+  TrophyIcon,
+  GlobeAltIcon,
+} from './components/Icons';
 
 export const MOCK_CAMPAIGN_DATA: Campaign[] = [];
 
@@ -13,6 +21,7 @@ export const NAVIGATION_ITEMS: NavItem[] = [
   { id: 'campaigns', label: 'Campaigns', icon: MegaphoneIcon, roles: ['chief'] },
   { id: 'goals', label: 'Set Goals', icon: TrophyIcon, roles: ['chief'] },
   { id: 'plan-builder', label: 'Plan Builder', icon: ClipboardDocumentListIcon, roles: ['chief'] },
+  { id: 'social-media', label: 'Social Media', icon: GlobeAltIcon, roles: ['chief', 'staff'] },
 ];
 
 export const ENTRY_TYPES = Object.values(EntryType);

--- a/types.ts
+++ b/types.ts
@@ -39,7 +39,15 @@ export interface KpiGoal {
   campaign_id?: number;
 }
 
-export type View = 'dashboard' | 'table' | 'data-entry' | 'plan-builder' | 'campaigns' | 'profile' | 'goals';
+export type View =
+  | 'dashboard'
+  | 'table'
+  | 'data-entry'
+  | 'plan-builder'
+  | 'campaigns'
+  | 'profile'
+  | 'goals'
+  | 'social-media';
 
 export type Role = 'chief' | 'staff';
 


### PR DESCRIPTION
## Summary
- add a social media workspace where teams can log links, placements, and notes for posts across supported networks
- introduce chief-only automated feed cards to manage connection state and sync cadence for each network
- expose the new experience through navigation updates and view wiring

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54ba5b4fc8328822ae2e42deaf15e