### PR TITLE
Add campaign linking to social media activity

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -304,7 +304,7 @@ const App: React.FC = () => {
       case 'goals':
         return <GoalSetter goals={goals} onAddGoal={addGoal} campaigns={campaigns} />;
       case 'social-media':
-        return <SocialMedia role={profile.role} />;
+        return <SocialMedia role={profile.role} campaigns={campaigns} />;
       case 'profile':
         return <ProfilePage session={session!} profile={profile} onProfileUpdate={onProfileUpdate} />;
       default:


### PR DESCRIPTION
## Summary
- allow saved social media posts to be linked to campaigns through a new selector
- display the linked campaign name in the saved links table and guide users when none exist
- pass campaign data into the social media screen so it can surface available campaigns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e55abe7dc0832881b1ea5c232b2fe4