### PR TITLE
Avoid showing loading spinner when returning to the tab

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -144,7 +144,7 @@ const App: React.FC = () => {
     [fetchKpiData, fetchCampaigns, fetchGoals, showToast]
   );
 
-  const initializeSession = useCallback(async () => {
+  const initializeSession = useCallback(async (options: { showLoading?: boolean } = {}) => {
     if (isInitializingRef.current) {
       return;
     }
@@ -152,7 +152,7 @@ const App: React.FC = () => {
     isInitializingRef.current = true;
 
     try {
-      if (isMountedRef.current) {
+      if (isMountedRef.current && options.showLoading !== false) {
         setIsLoading(true);
       }
 
@@ -240,13 +240,13 @@ const App: React.FC = () => {
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        void initializeSession();
+        void initializeSession({ showLoading: false });
       }
     };
 
     const handlePageShow = (event: PageTransitionEvent) => {
       if (event.persisted) {
-        void initializeSession();
+        void initializeSession({ showLoading: false });
       }
     };
 


### PR DESCRIPTION
## Summary
- add an optional flag to initializeSession so callers can skip the loading spinner when refreshing the session
- use the non-loading option for visibility and pageshow events to keep the UI visible when returning to the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e58fc2095c8328bc44a821ceaab412