### PR TITLE
Fix Tailwind PostCSS plugin configuration

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,6 @@
+const tailwindcss = require('@tailwindcss/postcss');
+const autoprefixer = require('autoprefixer');
+
 module.exports = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
-  },
+  plugins: [tailwindcss, autoprefixer],
 };


### PR DESCRIPTION
## Summary
- load the Tailwind CSS PostCSS plugin explicitly from `@tailwindcss/postcss`
- require autoprefixer directly so both plugins run during the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5a14a7acc8328bec89e1cb0873eb8