### PR TITLE
Fix blank screen by bundling dependencies locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,19 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>USACE PAO KPI Tracker</title>
-    <script type="importmap">
-      {
-        "imports": {
-          "react/": "https://aistudiocdn.com/react@^18.2.0/",
-          "react": "https://aistudiocdn.com/react@^18.2.0",
-          "recharts": "https://aistudiocdn.com/recharts@^2.12.0",
-          "react-dom/": "https://aistudiocdn.com/react-dom@^18.2.0/",
-          "react-dom/client": "https://aistudiocdn.com/react-dom@^18.2.0/client",
-          "@google/genai": "https://aistudiocdn.com/@google/genai@^1.22.0",
-          "@supabase/supabase-js": "https://aistudiocdn.com/@supabase/supabase-js@^2.45.0"
-        }
-      }
-    </script>
+    <!-- All dependencies are bundled locally by Vite. -->
   </head>
   <body class="bg-navy-50 dark:bg-navy-950">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- remove the CDN import map from `index.html` so Vite serves bundled dependencies locally and the app can boot without external CDNs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5a4e51b248328aee7150499e7008a