### PR TITLE
Improve sidebar interaction and card responsiveness

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -96,7 +96,7 @@ const Dashboard: React.FC<DashboardProps> = ({ data, campaigns, goals }) => {
           </select>
         </div>
       </div>
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         <KpiCard title="Media Pickups (Latest)" value={mediaPickupsLatest?.quantity.toLocaleString() ?? 'N/A'} unit="pickups" icon={PresentationChartBarIcon} />
         <KpiCard title="Social Engagement (Latest)" value={engagementLatest?.quantity.toLocaleString() ?? 'N/A'} unit="%" icon={ChartPieIcon}/>
         <KpiCard title="News Releases (Total)" value={pressReleasesTotal.toLocaleString() ?? 'N/A'} unit="releases" icon={GlobeAltIcon}/>

--- a/components/KpiCard.tsx
+++ b/components/KpiCard.tsx
@@ -11,17 +11,17 @@ interface KpiCardProps {
 
 const KpiCard: React.FC<KpiCardProps> = ({ title, value, unit, icon: Icon }) => {
   return (
-    <div className="glass-panel flex flex-col gap-6 p-6">
+    <div className="glass-panel flex flex-col gap-5 p-4 sm:gap-6 sm:p-5 lg:p-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="card-title">{title}</p>
-          <p className="mt-3 text-3xl font-semibold text-navy-900 dark:text-white">{value}</p>
+          <p className="mt-3 text-2xl font-semibold text-navy-900 sm:text-3xl dark:text-white">{value}</p>
         </div>
-        <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-usace-red to-usace-blue text-white shadow-md shadow-usace-blue/40">
-          <Icon className="h-6 w-6" aria-hidden="true" />
+        <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-usace-red to-usace-blue text-white shadow-md shadow-usace-blue/40 sm:h-12 sm:w-12">
+          <Icon className="h-5 w-5 sm:h-6 sm:w-6" aria-hidden="true" />
         </span>
       </div>
-      {unit && <span className="soft-badge w-fit">{unit}</span>}
+      {unit && <span className="soft-badge w-fit text-[10px] sm:text-xs">{unit}</span>}
     </div>
   );
 };

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavItem, View } from '../types';
 import { UsaceLogoIcon, XMarkIcon } from './Icons';
 
@@ -13,6 +13,16 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ navigationItems, activeView, setActiveView, isOpen = true, onClose }) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const isExpanded = isOpen || isHovered;
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsHovered(false);
+    }
+  }, [isOpen]);
+
   const handleNavigate = (view: View) => {
     setActiveView(view);
     if (onClose) {
@@ -22,16 +32,29 @@ const Sidebar: React.FC<SidebarProps> = ({ navigationItems, activeView, setActiv
 
   return (
     <aside
-      className={`fixed inset-y-0 left-0 z-40 flex w-72 transform flex-col bg-gradient-to-br from-navy-950/95 via-navy-900/95 to-usace-blue/90 text-white shadow-[0_24px_60px_-30px_rgba(15,23,42,0.75)] backdrop-blur-2xl transition-transform duration-300 ease-in-out lg:static lg:z-auto lg:translate-x-0 lg:flex-shrink-0 lg:shadow-none ${
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      className={`group/sidebar fixed inset-y-0 left-0 z-40 flex w-72 transform flex-col bg-gradient-to-br from-navy-950/95 via-navy-900/95 to-usace-blue/90 text-white shadow-[0_24px_60px_-30px_rgba(15,23,42,0.75)] backdrop-blur-2xl transition-all duration-300 ease-in-out lg:static lg:z-auto lg:flex-shrink-0 ${
         isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
-      }`}
+      } ${isExpanded ? 'lg:w-72 lg:shadow-[0_24px_60px_-30px_rgba(15,23,42,0.75)]' : 'lg:w-20 lg:shadow-[0_18px_45px_-28px_rgba(15,23,42,0.7)]'}`}
     >
-      <div className="relative flex h-20 items-center justify-center border-b border-white/10 px-6">
-        <div className="flex items-center gap-3">
+      <div className={`relative flex h-20 items-center justify-center border-b border-white/10 px-6 transition-all duration-200 ${
+        isExpanded ? '' : 'lg:px-0'
+      }`}>
+        <div
+          className={`flex items-center gap-3 transition-all duration-200 ${
+            isExpanded ? '' : 'lg:flex-col lg:gap-1'
+          }`}
+        >
           <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-usace-red">
             <UsaceLogoIcon className="h-7 w-7" />
           </span>
-          <div>
+          <div
+            className={`origin-left transition-all duration-200 ${
+              isExpanded ? 'scale-100 opacity-100' : 'scale-90 opacity-0 lg:hidden'
+            }`}
+            aria-hidden={!isExpanded}
+          >
             <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/70">USACE</p>
             <span className="text-lg font-semibold tracking-tight">PAO Metrics</span>
           </div>
@@ -47,17 +70,24 @@ const Sidebar: React.FC<SidebarProps> = ({ navigationItems, activeView, setActiv
           </button>
         )}
       </div>
-      <nav className="flex-1 space-y-2 overflow-y-auto px-5 py-8 subtle-scrollbar">
+      <nav
+        className={`flex-1 space-y-2 overflow-y-auto px-5 py-8 transition-[padding] duration-200 subtle-scrollbar ${
+          isExpanded ? '' : 'lg:px-3 lg:py-6'
+        }`}
+      >
         {navigationItems.map((item) => {
           const isActive = activeView === item.id;
           return (
             <button
               key={item.id}
               onClick={() => handleNavigate(item.id)}
+              aria-label={item.label}
               className={`group flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-sm font-semibold transition-all duration-200 ${
                 isActive
                   ? 'bg-white text-navy-900 shadow-lg shadow-black/20'
                   : 'bg-white/5 text-white/70 hover:-translate-y-0.5 hover:bg-white/10 hover:text-white'
+              } ${
+                isExpanded ? '' : 'lg:justify-center lg:px-2'
               }`}
             >
               <span
@@ -69,13 +99,31 @@ const Sidebar: React.FC<SidebarProps> = ({ navigationItems, activeView, setActiv
               >
                 <item.icon className="h-5 w-5" />
               </span>
-              <span>{item.label}</span>
+              <span
+                className={`whitespace-nowrap text-left transition-all duration-200 ${
+                  isExpanded ? 'max-w-xs opacity-100' : 'max-w-0 opacity-0 lg:hidden'
+                }`}
+                aria-hidden={!isExpanded}
+              >
+                {item.label}
+              </span>
             </button>
           );
         })}
       </nav>
-      <div className="border-t border-white/10 p-6">
-        <p className="text-center text-[11px] uppercase tracking-[0.4em] text-white/60">&copy; 2024 USACE PAO</p>
+      <div
+        className={`border-t border-white/10 p-6 transition-[padding] duration-200 ${
+          isExpanded ? '' : 'lg:px-0'
+        }`}
+      >
+        <p
+          className={`text-center text-[11px] uppercase tracking-[0.4em] text-white/60 transition-opacity duration-200 ${
+            isExpanded ? 'opacity-100' : 'opacity-0 lg:hidden'
+          }`}
+          aria-hidden={!isExpanded}
+        >
+          &copy; 2024 USACE PAO
+        </p>
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- add hover-triggered expansion so the sidebar peeks on desktop, slides out on hover, and remains toggleable on mobile
- adjust KPI cards with responsive spacing and typography and rebalance the dashboard grid for better readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5dc6fe2c88328a460751004423a32