### PR TITLE
Ensure desktop sidebar remains open and refine card layout

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -96,7 +96,7 @@ const Dashboard: React.FC<DashboardProps> = ({ data, campaigns, goals }) => {
           </select>
         </div>
       </div>
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
         <KpiCard title="Media Pickups (Latest)" value={mediaPickupsLatest?.quantity.toLocaleString() ?? 'N/A'} unit="pickups" icon={PresentationChartBarIcon} />
         <KpiCard title="Social Engagement (Latest)" value={engagementLatest?.quantity.toLocaleString() ?? 'N/A'} unit="%" icon={ChartPieIcon}/>
         <KpiCard title="News Releases (Total)" value={pressReleasesTotal.toLocaleString() ?? 'N/A'} unit="releases" icon={GlobeAltIcon}/>
@@ -112,7 +112,7 @@ const Dashboard: React.FC<DashboardProps> = ({ data, campaigns, goals }) => {
             </span>
             <h3 className="text-2xl font-semibold text-navy-900 dark:text-white">Active Goals</h3>
           </div>
-          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
             {activeGoals.map(goal => {
               const currentValue = getGoalProgress(goal);
               const campaignName = goal.campaign_id

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -14,8 +14,30 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({ navigationItems, activeView, setActiveView, isOpen = true, onClose }) => {
   const [isHovered, setIsHovered] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
 
-  const isExpanded = isOpen || isHovered;
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(min-width: 1024px)');
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      setIsDesktop(event.matches);
+    };
+
+    setIsDesktop(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleMediaChange);
+      return () => mediaQuery.removeEventListener('change', handleMediaChange);
+    }
+
+    mediaQuery.addListener(handleMediaChange);
+    return () => mediaQuery.removeListener(handleMediaChange);
+  }, []);
+
+  const isExpanded = isDesktop || isOpen || isHovered;
 
   useEffect(() => {
     if (!isOpen) {
@@ -35,7 +57,7 @@ const Sidebar: React.FC<SidebarProps> = ({ navigationItems, activeView, setActiv
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       className={`group/sidebar fixed inset-y-0 left-0 z-40 flex w-72 transform flex-col bg-gradient-to-br from-navy-950/95 via-navy-900/95 to-usace-blue/90 text-white shadow-[0_24px_60px_-30px_rgba(15,23,42,0.75)] backdrop-blur-2xl transition-all duration-300 ease-in-out lg:static lg:z-auto lg:flex-shrink-0 ${
-        isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
+        isDesktop || isOpen ? 'translate-x-0' : '-translate-x-full'
       } ${isExpanded ? 'lg:w-72 lg:shadow-[0_24px_60px_-30px_rgba(15,23,42,0.75)]' : 'lg:w-20 lg:shadow-[0_18px_45px_-28px_rgba(15,23,42,0.7)]'}`}
     >
       <div className={`relative flex h-20 items-center justify-center border-b border-white/10 px-6 transition-all duration-200 ${

--- a/index.css
+++ b/index.css
@@ -32,8 +32,8 @@
     position: relative;
     overflow: hidden;
     border-radius: 1.5rem;
-    border: 1px solid rgba(255, 255, 255, 0.6);
-    background-color: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    background-color: rgba(255, 255, 255, 0.68);
     padding: 1.5rem;
     box-shadow: 0 24px 60px -30px rgba(15, 23, 42, 0.55);
     backdrop-filter: blur(24px);
@@ -41,8 +41,8 @@
   }
 
   .dark .glass-panel {
-    border-color: rgba(255, 255, 255, 0.1);
-    background-color: rgba(15, 23, 42, 0.6);
+    border-color: rgba(255, 255, 255, 0.08);
+    background-color: rgba(15, 23, 42, 0.52);
     box-shadow: 0 24px 60px -30px rgba(0, 0, 0, 0.75);
   }
 
@@ -50,13 +50,13 @@
     content: '';
     position: absolute;
     inset: 0;
-    background: radial-gradient(circle at top, rgba(255, 255, 255, 0.7), transparent 55%);
-    opacity: 0.35;
+    background: radial-gradient(circle at top, rgba(255, 255, 255, 0.6), transparent 55%);
+    opacity: 0.28;
     pointer-events: none;
   }
 
   .dark .glass-panel::before {
-    background: radial-gradient(circle at top, rgba(148, 163, 184, 0.45), transparent 55%);
+    background: radial-gradient(circle at top, rgba(148, 163, 184, 0.35), transparent 55%);
   }
 
   .glass-panel > * {


### PR DESCRIPTION
## Summary
- keep the sidebar expanded on desktop viewports while still collapsing on mobile
- limit dashboard KPI and goal cards to two-column layouts for a less stretched presentation
- soften glass panel backgrounds to provide a lighter, more transparent card appearance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e634ca7f0083289955e799b7191b42