### PR TITLE
Switch auth flow to Supabase login module

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Session } from '@supabase/supabase-js';
 import { useNavigate } from 'react-router-dom';
-import { signOut as firebaseSignOut } from 'firebase/auth';
 import { supabase } from '../lib/supabase';
-import { auth } from '../lib/firebase';
 import ThemeToggle from './ThemeToggle';
 import Avatar from './Avatar';
 import { Profile, View } from '../types';
@@ -33,12 +31,6 @@ const Header: React.FC<HeaderProps> = ({
   const navigate = useNavigate();
 
   const handleSignOut = async () => {
-    try {
-      await firebaseSignOut(auth);
-    } catch (error) {
-      console.error('Firebase sign-out failed', error);
-    }
-
     if (isSupabaseEnabled) {
       try {
         await supabase.auth.signOut();
@@ -48,7 +40,7 @@ const Header: React.FC<HeaderProps> = ({
     }
 
     navigate('/login', { replace: true });
-  }
+  };
 
   const showAccountMenu = Boolean(session && isSupabaseEnabled);
   const primaryLabel = session?.user?.email ?? profile?.teamName ?? 'USACE Public Affairs';

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -1,5 +1,20 @@
-import AuthCard from "../components/AuthCard";
+import { Navigate, useLocation, type Location } from "react-router-dom";
+import Auth from "../components/Auth";
+import { useAuth } from "../contexts/AuthProvider";
+
+type RedirectState = {
+  from?: Location;
+};
 
 export default function Login() {
-  return <AuthCard initialMode="login" />;
+  const { session, loading, supabaseEnabled } = useAuth();
+  const location = useLocation();
+  const redirectState = location.state as RedirectState | undefined;
+  const redirectTo = redirectState?.from?.pathname ?? "/";
+
+  if (supabaseEnabled && !loading && session) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return <Auth initialMode="signIn" />;
 }

--- a/pages/Register.tsx
+++ b/pages/Register.tsx
@@ -1,5 +1,20 @@
-import AuthCard from "../components/AuthCard";
+import { Navigate, useLocation, type Location } from "react-router-dom";
+import Auth from "../components/Auth";
+import { useAuth } from "../contexts/AuthProvider";
+
+type RedirectState = {
+  from?: Location;
+};
 
 export default function Register() {
-  return <AuthCard initialMode="register" />;
+  const { session, loading, supabaseEnabled } = useAuth();
+  const location = useLocation();
+  const redirectState = location.state as RedirectState | undefined;
+  const redirectTo = redirectState?.from?.pathname ?? "/";
+
+  if (supabaseEnabled && !loading && session) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return <Auth initialMode="signUp" />;
 }

--- a/routes/Protected.tsx
+++ b/routes/Protected.tsx
@@ -2,10 +2,20 @@ import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "../contexts/AuthProvider";
 
 export default function Protected() {
-  const { user, loading } = useAuth();
-  const loc = useLocation();
+  const { session, loading, supabaseEnabled } = useAuth();
+  const location = useLocation();
 
-  if (loading) return <div className="p-6">Loading…</div>;
-  if (!user) return <Navigate to="/login" replace state={{ from: loc }} />;
+  if (!supabaseEnabled) {
+    return <Outlet />;
+  }
+
+  if (loading) {
+    return <div className="p-6">Loading…</div>;
+  }
+
+  if (!session) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
   return <Outlet />;
 }


### PR DESCRIPTION
## Summary
- replace the firebase-based auth provider and route guard with a supabase session-aware context
- update the login and register pages to render the supabase auth module and redirect signed-in users
- enhance the auth component to support both modes, fetch teams, and navigate between login and registration while signing out through supabase

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed75051540832887c6527f48ba91ac